### PR TITLE
refactor: follow font weight guidance for syntax highlighting

### DIFF
--- a/themes/Catppuccin Frappé.xccolortheme
+++ b/themes/Catppuccin Frappé.xccolortheme
@@ -170,7 +170,7 @@
 		<key>xcode.syntax.comment.doc</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.declaration.other</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.declaration.type</key>
@@ -200,9 +200,9 @@
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.mark</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.number</key>

--- a/themes/Catppuccin Latte.xccolortheme
+++ b/themes/Catppuccin Latte.xccolortheme
@@ -170,7 +170,7 @@
 		<key>xcode.syntax.comment.doc</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.declaration.other</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.declaration.type</key>
@@ -200,9 +200,9 @@
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.mark</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.number</key>

--- a/themes/Catppuccin Macchiato.xccolortheme
+++ b/themes/Catppuccin Macchiato.xccolortheme
@@ -170,7 +170,7 @@
 		<key>xcode.syntax.comment.doc</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.declaration.other</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.declaration.type</key>
@@ -200,9 +200,9 @@
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.mark</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.number</key>

--- a/themes/Catppuccin Mocha.xccolortheme
+++ b/themes/Catppuccin Mocha.xccolortheme
@@ -170,7 +170,7 @@
 		<key>xcode.syntax.comment.doc</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.declaration.other</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.declaration.type</key>
@@ -200,9 +200,9 @@
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.mark</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.number</key>

--- a/xcode.tera
+++ b/xcode.tera
@@ -186,7 +186,7 @@ whiskers:
 		<key>xcode.syntax.comment.doc</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.declaration.other</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.declaration.type</key>
@@ -216,9 +216,9 @@ whiskers:
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.mark</key>
-		<string>SFMono-Regular - 14.0</string>
+		<string>SFMono-Bold - 14.0</string>
 		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 14.0</string>
 		<key>xcode.syntax.number</key>


### PR DESCRIPTION
Proposed PR to address issue: https://github.com/catppuccin/xcode/issues/13
|Frappé|Latte|
|-|-|
|![Screenshot 2024-10-29 at 1 09 32 PM](https://github.com/user-attachments/assets/4fe944f2-02f6-478c-b137-4b658eb53501)|![Screenshot 2024-10-29 at 1 09 34 PM](https://github.com/user-attachments/assets/8aecdde4-29d7-4630-ae2c-9b30b45dc5ad)|
|Macchiato|Mocha|
|![Screenshot 2024-10-29 at 1 09 41 PM](https://github.com/user-attachments/assets/09ab4793-e913-4528-b54d-21f645d0c53a)|![Screenshot 2024-10-29 at 1 09 43 PM](https://github.com/user-attachments/assets/aea809d1-3cea-49ad-9f96-2ef05b9b0ac4)|
